### PR TITLE
Handle invalid URL patterns in popup and storage

### DIFF
--- a/src/popup_sites.js
+++ b/src/popup_sites.js
@@ -35,6 +35,13 @@ form.addEventListener('submit', async (e) => {
     messageDiv.textContent = 'パターンを入力してください';
     return;
   }
+  // URLPattern 生成時に例外が出ることがあるため事前に検証
+  try {
+    new URLPattern(pattern);
+  } catch (err) {
+    messageDiv.textContent = '無効なURLパターンです';
+    return;
+  }
   try {
     await addSite(pattern);
     messageDiv.textContent = '登録しました';

--- a/src/storage.js
+++ b/src/storage.js
@@ -104,5 +104,12 @@ export async function removeSite(urlPattern) {
 export async function isSiteRegistered(url) {
   const data = await chrome.storage.local.get(SITES_KEY);
   const sites = data[SITES_KEY] || [];
-  return sites.some(pattern => new URLPattern(pattern).test(url));
+  return sites.some(pattern => {
+    // パターンが不正な場合は URLPattern コンストラクタが例外を投げる
+    try {
+      return new URLPattern(pattern).test(url);
+    } catch {
+      return false;
+    }
+  });
 }


### PR DESCRIPTION
## Summary
- validate URL pattern input in popup
- ignore invalid patterns when matching stored sites

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843f53a82f08329a8f2f36857307664