### PR TITLE
Add validation for semicolons in keywords

### DIFF
--- a/src/popup_register.html
+++ b/src/popup_register.html
@@ -12,6 +12,7 @@
     <label>
       キーワード:<br>
       <input type="text" id="keyword-input" required placeholder="例: summary-mode">
+      <br><small>セミコロン(;)は使用できません</small>
     </label><br>
     <label>
       置換文:<br>

--- a/src/popup_register.js
+++ b/src/popup_register.js
@@ -26,6 +26,10 @@ templateForm.addEventListener('submit', async (e) => {
     messageDiv.textContent = 'キーワードと置換文は必須です';
     return;
   }
+  if (key.includes(';')) {
+    messageDiv.textContent = 'キーワードにセミコロンは使用できません';
+    return;
+  }
   await setTemplate(key, content);
   messageDiv.textContent = '保存しました';
   keywordInput.value = '';


### PR DESCRIPTION
## Summary
- prevent semicolons from being used in keywords on the register popup
- show a short note in the register form describing that semicolons are not allowed

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6843fcaf17508329a007be57cfd55c65