### PR TITLE
Update placeholder for keyword hint

### DIFF
--- a/src/popup_register.html
+++ b/src/popup_register.html
@@ -11,7 +11,8 @@
   <form id="template-form">
     <label>
       キーワード:<br>
-      <input type="text" id="keyword-input" required placeholder="例: summary-mode">
+      <input type="text" id="keyword-input" required placeholder="例: summary">
+      <small>メッセージでは <code>;;キーワード;;</code> と書きます</small>
     </label><br>
     <label>
       置換文:<br>


### PR DESCRIPTION
## Summary
- clarify how to use keywords with `;;keyword;;` in the registration popup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843fcb0477c8329ad274b9ea4abd2c8