### PR TITLE
Fix injection method and remove stray HTML text

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -8,8 +8,7 @@ chrome.webNavigation.onCompleted.addListener(async (details) => {
     try {
       await chrome.scripting.executeScript({
         target: { tabId: details.tabId },
-        func: (url) => import(url),
-        args: [chrome.runtime.getURL('src/content.js')]
+        files: ['src/content.js']
       });
     } catch (err) {
       console.error('Injection failed', err);

--- a/src/popup_register.html
+++ b/src/popup_register.html
@@ -11,10 +11,8 @@
   <form id="template-form">
     <label>
       キーワード:<br>
-      codex/add-semicolon-check-in-submit-handler
       <input type="text" id="keyword-input" required placeholder="例: summary-mode">
       <br><small>セミコロン(;)は使用できません</small>
-      main
     </label><br>
     <label>
       置換文:<br>


### PR DESCRIPTION
## Summary
- execute the content script using `files` instead of dynamic import
- clean up stray debugging text in the registration popup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843f99c2ba88329a7e74fcdfbdc2f70