### PR TITLE
Add skip injection log in background script

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -14,5 +14,7 @@ chrome.webNavigation.onCompleted.addListener(async (details) => {
     } catch (err) {
       console.error('Injection failed for', url, err);
     }
+  } else {
+    console.log('Skipping injection for', url);
   }
 });


### PR DESCRIPTION
## Summary
- log when skipping content script injection if a site isn't registered

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684416aaf6e08329b44e09d326922191